### PR TITLE
gitcache: test GitCache directly

### DIFF
--- a/gitcache/gitcache.go
+++ b/gitcache/gitcache.go
@@ -11,7 +11,7 @@ import (
 
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing/object"
-	githttp "gopkg.in/src-d/go-git.v4/plumbing/transport/http"
+	"gopkg.in/src-d/go-git.v4/plumbing/transport"
 
 	"github.com/merklecounty/rget/autocert"
 )
@@ -19,7 +19,7 @@ import (
 type GitCache struct {
 	dir  autocert.DirCache
 	repo git.Repository
-	auth githttp.BasicAuth
+	auth transport.AuthMethod
 }
 
 func prefix(dir autocert.DirCache, prefix string) (matches []string, err error) {
@@ -48,7 +48,7 @@ func prefix(dir autocert.DirCache, prefix string) (matches []string, err error) 
 	return
 }
 
-func NewGitCache(url string, auth githttp.BasicAuth, dir string) (*GitCache, error) {
+func NewGitCache(url string, auth transport.AuthMethod, dir string) (*GitCache, error) {
 	gc := GitCache{
 		dir:  autocert.DirCache(dir),
 		auth: auth,
@@ -57,7 +57,7 @@ func NewGitCache(url string, auth githttp.BasicAuth, dir string) (*GitCache, err
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		fmt.Printf("git clone %s %s --recursive\n", url, dir)
 		r, err := git.PlainClone(dir, false, &git.CloneOptions{
-			Auth:              &gc.auth,
+			Auth:              gc.auth,
 			URL:               url,
 			RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
 		})
@@ -151,7 +151,7 @@ func (g GitCache) Put(ctx context.Context, name string, data []byte) error {
 	fmt.Printf("git push\n")
 	// push using default options
 	err = g.repo.Push(&git.PushOptions{
-		Auth: &g.auth,
+		Auth: g.auth,
 	})
 	if err != nil {
 		return err

--- a/gitcache/gitcache_test.go
+++ b/gitcache/gitcache_test.go
@@ -8,28 +8,65 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/merklecounty/rget/autocert"
+	"gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
 )
 
-func TestDirCache(t *testing.T) {
+func TestPrefix(t *testing.T) {
 	dir, err := ioutil.TempDir("", "autocert")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(dir)
-	dir = filepath.Join(dir, "certs") // a nonexistent dir
-	cache := autocert.DirCache(dir)
+
+	url := filepath.Join(dir, "repo")
+	err = os.Mkdir(url, 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := git.PlainInit(url, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w, err := r.Worktree()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ioutil.WriteFile(filepath.Join(url, "README"), []byte("Hello world"), 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = w.Add("README")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = w.Commit("README\n", &git.CommitOptions{Author: &object.Signature{
+		Name: "Zohra",
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	println(url)
+	gc, err := NewGitCache(filepath.Join(url, git.GitDirName), nil, filepath.Join(dir, "cache"))
+	if err != nil {
+		t.Fatal(err)
+	}
 	ctx := context.Background()
 
-	// test prefix
 	expected := []string{"dummy1", "dummy1.dummy1", "dummy1.dummy1.dummy1"}
 	for _, n := range expected {
-		if err := cache.Put(ctx, n, []byte{1}); err != nil {
+		if err := gc.Put(ctx, n, []byte{1}); err != nil {
 			t.Fatalf("put: %v", err)
 		}
 	}
 
-	matches, err := prefix(cache, "dummy")
+	matches, err := gc.Prefix(ctx, "dummy")
 	if err != nil {
 		t.Fatalf("prefix: %v", err)
 	}
@@ -37,5 +74,4 @@ func TestDirCache(t *testing.T) {
 	if !reflect.DeepEqual(matches, expected) {
 		t.Errorf("matches = %v; want %v", matches, expected)
 	}
-
 }

--- a/rget/cmd/server.go
+++ b/rget/cmd/server.go
@@ -135,13 +135,13 @@ func server(cmd *cobra.Command, args []string) {
 		Password: password,
 	}
 
-	pubgc, err := gitcache.NewGitCache(pubgit, auth, "public")
+	pubgc, err := gitcache.NewGitCache(pubgit, &auth, "public")
 	if err != nil {
 		panic(err)
 	}
 	http.HandleFunc("/", sumRepo(*pubgc).handler)
 
-	privgc, err := gitcache.NewGitCache(privgit, auth, "private")
+	privgc, err := gitcache.NewGitCache(privgit, &auth, "private")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Initialize a repo in the test to test the basic operations. This will
greatly increase code coverage.