### PR TITLE
production: use quay.io/merklecounty images

### DIFF
--- a/production/sserve.yaml
+++ b/production/sserve.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: sgetserve
-        image: quay.io/established/sget
+        image: quay.io/merklecounty/rget
         imagePullPolicy: Always
         env:
         - name: PUBLIC_REPO


### PR DESCRIPTION
use the images built from the github.com/merklecounty/rget repo directly
for now.