### PR TITLE
Improve wording of the developer usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,20 @@ rget https://github.com/merklecounty/rget/releases/download/v0.0.6/rget-v0.0.6-l
 
 ### GitHub Developer Usage
 
-Generate SHA256SUMS for a GitHub release and upload to the GitHub releases page
+It takes two commands to make a release available for verified download with rget:
 
 ```
 rget github publish-release-sums https://github.com/merklecounty/rget/releases/tag/v0.0.6
-```
 
-### Submit a SHA256SUMS to the log
-
-```
 rget submit https://github.com/merklecounty/rge/releases/download/v0.0.6/SHA256SUMS
 ```
+The first command will start a local web server and open a Github authorization URL
+in your browser. You will have 120 seconds to authorize it.
+
+When authorized, it will calculate SHA256 sums for every file in the release,
+create a `SHA256SUMS` file, and add it to the Github release.
+
+The second command will submit the sums to the log.
 
 ## Administration Usage
 


### PR DESCRIPTION
The original wording is a bit confusing and makes it sound like you should generate SHA256 sums and upload it to github, and then run rget github.

It's also nice to know what exactly will happen when you run a command.