### PR TITLE
rgetct: add missing return statement

### DIFF
--- a/rgetct/ct.go
+++ b/rgetct/ct.go
@@ -37,6 +37,7 @@ func CheckX509(ctx context.Context, lf logInfoFactory, chain []*x509.Certificate
 		issuer, err = x509util.GetIssuer(leaf, hc)
 		if err != nil {
 			fmt.Printf("Failed to get issuer online: %v\n", err)
+			return
 		}
 	} else {
 		issuer = chain[1]


### PR DESCRIPTION
Without it, "ct.MerkleTreeLeafForEmbeddedSCT" might get called with a "nil" issuer, resulting in a nil pointer dereference.
See https://github.com/google/certificate-transparency-go/blob/cb150c95c86291443da938a5973c249ed1458e87/serialization.go#L221.