### PR TITLE
rgetserver: Fix vanity URL import path

### DIFF
--- a/rgetserver/rgetserver.go
+++ b/rgetserver/rgetserver.go
@@ -1,4 +1,4 @@
-package rgetserver // import "go.merklecounty.com/rgetserver"
+package rgetserver // import "go.merklecounty.com/rget/rgetserver"
 
 import (
 	"context"


### PR DESCRIPTION
It appears that some time between 4c7b2f3abda833c465f3ac25680c99d2522caeaf
and 3eb5112294a0d2dd560fe7ed5fafb7c90268c860 that import path ([1]) may have
mutated.  In most packages the import path is set to the form:

go.merklecounty.com/rget/{package}

while prior to this commit the path specifically for rgetserver is:

go.merklecounty.com/{package}

This was discovered when attempting to build a modified version while
working on #13 and running into the following error:

```
rget/cmd/server.go:33:2: code in directory /home/bharrington/Projects/golang/src/go.merklecounty.com/rget/rgetserver expects import "go.merklecounty.com/rgetserver"
```

[1]: https://golang.org/cmd/go/#hdr-Import_path_checking